### PR TITLE
docker起動時にsqlにデータベースとテーブルを作成する処理をしたかったのだが、できず。困る。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: "mysql"
     restart: always
     volumes:
+      - ./project/database/initdb.d:/docker-entrypoint-initdb.d
       - mysql_data:/var/lib/mysql
       - ./project/database/my.cnf:/etc/mysql/conf.d/my.cnf
     platform: linux/amd64

--- a/project/database/initdb.d/create_image_table.sql
+++ b/project/database/initdb.d/create_image_table.sql
@@ -1,0 +1,13 @@
+DROP DATABASE IF EXISTS bookcover_db;
+CREATE DATABASE IF NOT EXISTS bookcover_db;
+USE bookcover_db;
+
+CREATE TABLE IF NOT EXISTS image (
+    id INT NOT NULL AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    image_path VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO image (name,image_path) VALUES ("flower","etc/image/flower");
+INSERT INTO image (name,image_path) VALUES ("cat","etc/image/cat");

--- a/project/server/app/main.py
+++ b/project/server/app/main.py
@@ -1,7 +1,29 @@
-from fastapi import FastAPI
+from fastapi import FastAPI,File,UploadFile
+
+import shutil
+import os
+
 
 app = FastAPI()
 
-@app.get("/")
+#
+@app.get("/make")
 def read_root():
   return {"Hello": "World"}
+
+#
+@app.post("/files/")
+async def file(file: bytes = File(...)):
+    content = file.decode('utf-8')
+    formatfile = content.split('\n')
+    return {'filedetail': formatfile}
+
+#
+@app.post("/uploadfile/")
+async def upload_file(file: UploadFile = File(...)):
+    return {'filename': file.filename}
+
+#
+@app.post("/take")
+def take():
+  return {"Hello":"World!!"}

--- a/project/server/requirements.txt
+++ b/project/server/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+mysqlclient
+sqlalchemy


### PR DESCRIPTION
docker起動時にsqlにデータベースとテーブルを作成する処理をしたかったのだが、できず。困る。
変えたのは
docker-compose.ymlファイルのvolumeに
- ./project/database/initdb.d:/docker-entrypoint-initdb.dを追記
 ./project/database/initdb.d内にcreate_image_table.sqlを記述

main.pyのコミットはミスなので、気にしないでください。